### PR TITLE
Bug fixed

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -80,6 +80,14 @@ namespace Wox.Plugin.ProcessKiller
                             if (!p.HasExited)
                             {
                                 p.Kill();
+                                if (!p.WaitForExit(10))
+                                {
+                                    MessageBox.Show("Process " + p.ProcessName + "(" + p.Id.ToString() + ") couldn't be killed")
+                                }
+                                catch (Exception exception)
+                                {
+                                    MessageBox.Show("Exception while trying to kill process " + p.ProcessName + "(" + p.Id.ToString() + "): " + exception.ToString());
+                                }
                             }
                             
                             return true;
@@ -102,6 +110,14 @@ namespace Wox.Plugin.ProcessKiller
                                    if (!p.HasExited)
                                    {
                                         p.Kill();
+                                        if (!p.WaitForExit(10))
+                                        {
+                                            MessageBox.Show("Process " + p.ProcessName + "(" + p.Id.ToString() + ") couldn't be killed")
+                                        }
+                                        catch (Exception exception)
+                                        {
+                                            MessageBox.Show("Exception while trying to kill process " + p.ProcessName + "(" + p.Id.ToString() + "): " + exception.ToString());
+                                        }
                                    }
                                }
                                return true;

--- a/Main.cs
+++ b/Main.cs
@@ -77,7 +77,11 @@ namespace Wox.Plugin.ProcessKiller
                         SubTitle = path,
                         Action = (c) =>
                         {
-                            p.Kill();
+                            if (!p.HasExited)
+                            {
+                                p.Kill();
+                            }
+                            
                             return true;
                         }
                     });
@@ -95,7 +99,10 @@ namespace Wox.Plugin.ProcessKiller
                            {
                                foreach (var p in processlist)
                                {
-                                   p.Kill();
+                                   if (!p.HasExited)
+                                   {
+                                        p.Kill();
+                                   }
                                }
                                return true;
                            }


### PR DESCRIPTION
When you kill a process and calling Wox again, it shows the process if you don't type anything and press ENTER, letting you kill a non existant process throwing an error.
I've added a check for HasExited in every p.kill
The ideal would be that the list clears whan you press ENTER but i don't know how to do it :)